### PR TITLE
Slight size fix for text small.

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
       sans: ["Poppins", "sans-serif"],
     },
     fontSize: {
-      sm: ["14px", "20px"],
+      sm: ["13px", "20px"],
       base: ["16px", "24px"],
       lg: ["20px", "28px"],
       xl: ["25px", "32px"],


### PR DESCRIPTION
there was a slight discrepancy in size of small font as defined by tw default compared to our major third type scale (see figma moodboard). 
fixed tw config to comply
