### PR TITLE
Headless UI patch

### DIFF
--- a/src/app/sandbox/date-picker/page.tsx
+++ b/src/app/sandbox/date-picker/page.tsx
@@ -19,6 +19,12 @@ function DatePickerPage() {
     year: 2024,
   });
 
+  const [value3, setValue3] = useState<TDate>({
+    day: 19,
+    month: 5,
+    year: 2024,
+  });
+
   return (
     <div>
       <div className="relative mx-auto mt-8 w-80">
@@ -31,6 +37,12 @@ function DatePickerPage() {
         A regular datepicker
         <div className="mt-2">
           <DatePicker value={value1} onChange={setValue1} />
+        </div>
+      </div>
+      <div className="relative mx-auto mt-8 w-80">
+        A second regular datepicker to test overflow
+        <div className="mt-2">
+          <DatePicker value={value3} onChange={setValue3} />
         </div>
       </div>
     </div>

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -572,7 +572,7 @@ function DatePicker({
         <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
           <div
             ref={calendarPaneRef}
-            className="absolute mt-2 w-[256px] min-[400px]:w-[298px] rounded-lg border border-neutral-400 bg-white px-2 py-3"
+            className="absolute z-50 mt-2 w-[256px] min-[400px]:w-[298px] rounded-lg border border-neutral-400 bg-white px-2 py-3"
           >
             <div className="flex justify-between">
               {/* month shuffler */}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -183,19 +183,14 @@ function InnerListBox({
         </ListboxButton>
       )}
 
-      <div
-        className={`absolute z-10 pb-2 ${
-          customTrigger
-            ? "w-auto whitespace-nowrap max-xs:fixed max-xs:left-4 max-xs:right-4"
-            : "w-full"
-        }`}
+      <ListboxOptions
+        anchor="bottom start"
+        className={`${!customTrigger && "min-w-[var(--button-width)] "}[--anchor-gap:8px] [--anchor-padding:8px] overflow-hidden rounded-lg border border-neutral-400 bg-white focus-visible:outline-none focus-visible:ring focus-visible:ring-blue-100`}
       >
-        <ListboxOptions className="mt-2 overflow-hidden rounded-lg border border-neutral-400 bg-white focus-visible:outline-none focus-visible:ring focus-visible:ring-blue-100">
-          <div ref={listboxOptionsRef} className="max-h-80 overflow-auto">
-            {children}
-          </div>
-        </ListboxOptions>
-      </div>
+        <div ref={listboxOptionsRef} className="max-h-80 overflow-auto">
+          {children}
+        </div>
+      </ListboxOptions>
     </>
   );
 }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -185,7 +185,7 @@ function InnerListBox({
 
       <ListboxOptions
         anchor="bottom start"
-        className={`${!customTrigger && "min-w-[var(--button-width)] "}[--anchor-gap:8px] [--anchor-padding:8px] overflow-hidden rounded-lg border border-neutral-400 bg-white focus-visible:outline-none focus-visible:ring focus-visible:ring-blue-100`}
+        className={`${!customTrigger && "min-w-[var(--button-width)] "} [--anchor-gap:8px] [--anchor-padding:8px] overflow-hidden rounded-lg border border-neutral-400 bg-white focus-visible:outline-none focus-visible:ring focus-visible:ring-blue-100`}
       >
         <div ref={listboxOptionsRef} className="max-h-80 overflow-auto">
           {children}


### PR DESCRIPTION
Select positioning solved with headless anchor. Made a change to the UI that makes panel min width same as the size of the button but wider if necessary. After trying out some solutions, this one seems the most sane to me, without overcomplicating things. 

Add z-index to datepicker so the "panel" goes over the next datepicker. I will make a proposal for the datepicker to use headlessui Popover, so it can use anchor logic for positioning as well. Next PR.