### PR TITLE
Fix map auto bounds from markers as seen on crag info page.

### DIFF
--- a/src/app/[lang]/crag/[cragSlug]/(crag)/info/page.tsx
+++ b/src/app/[lang]/crag/[cragSlug]/(crag)/info/page.tsx
@@ -23,7 +23,7 @@ import IconMissing from "@/components/ui/icons/missing";
 import Link from "@/components/ui/link";
 import { IconSize } from "@/components/ui/icons/icon-size";
 import IconMore from "@/components/ui/icons/more";
-import MapMarker from "@/components/map/map-marker";
+import { TLazyMapMarkerProps } from "@/components/map/lazy-map-marker";
 
 type TCragInfoPageParams = {
   cragSlug: string;
@@ -132,25 +132,20 @@ async function CragInfoPage({ params }: { params: TCragInfoPageParams }) {
     minimumFractionDigits: 5,
   });
 
-  // Construct array of all parkings and walls markers
-  const markers = Object.entries(parkings).map(
-    ([id, { lat, lon, sectors }]) => (
-      <MapMarker
-        key={id}
-        type="parking"
-        position={[lat, lon]}
-        popupContent={<ParkingMarkerPopupContent sectors={sectors} />}
-      />
-    )
+  // Construct array of all parkings and walls markers data
+  const markersData: TLazyMapMarkerProps[] = Object.entries(parkings).map(
+    ([_id, { lat, lon, sectors }]) => ({
+      type: "parking",
+      position: [lat, lon],
+      popupContent: <ParkingMarkerPopupContent sectors={sectors} />,
+    })
   );
   if (crag.lat && crag.lon) {
-    markers.push(
-      <MapMarker
-        type="wall"
-        position={[crag.lat, crag.lon]}
-        popupContent={<div>{`Plezališče ${crag.name}`}</div>}
-      />
-    );
+    markersData.push({
+      type: "wall",
+      position: [crag.lat, crag.lon],
+      popupContent: <div>{`Plezališče ${crag.name}`}</div>,
+    });
   }
 
   return (
@@ -331,8 +326,12 @@ async function CragInfoPage({ params }: { params: TCragInfoPageParams }) {
 
         {/* Map */}
         <div className="md:col-span-2">
-          {markers.length > 0 && (
-            <Map autoBounds markers={markers} className="xs:rounded-lg" />
+          {markersData.length > 0 && (
+            <Map
+              autoBounds
+              markersData={markersData}
+              className="xs:rounded-lg"
+            />
           )}
         </div>
       </div>

--- a/src/app/sandbox/map/map-event-demo.tsx
+++ b/src/app/sandbox/map/map-event-demo.tsx
@@ -8,6 +8,7 @@ function MapEventDemo() {
   const [position, setPosition] = useState<[number, number] | undefined>();
   const map = useMapEvent("click", (e) => {
     setPosition([e.latlng.lat, e.latlng.lng]);
+    console.log(e.latlng);
   });
 
   return (

--- a/src/app/sandbox/map/page.tsx
+++ b/src/app/sandbox/map/page.tsx
@@ -11,19 +11,17 @@ function MapPage() {
         className="rounded-lg"
         center={[45.567706816120364, 13.863458632993037]}
         zoom={17}
-        markers={[
-          <MapMarker
-            key={0}
-            type="parking"
-            position={[45.567196, 13.862597]}
-            popupContent={"Parkirišče Mišja peč"}
-          />,
-          <MapMarker
-            key={1}
-            type="wall"
-            position={[45.568112, 13.863984]}
-            popupContent="Plezališče Mišja peč"
-          />,
+        markersData={[
+          {
+            type: "parking",
+            position: [45.567196, 13.862597],
+            popupContent: "Parkirišče Mišja peč",
+          },
+          {
+            type: "wall",
+            position: [45.568112, 13.863984],
+            popupContent: "Plezališče Mišja peč",
+          },
         ]}
       >
         <MapEventDemo />

--- a/src/components/map/lazy-map.tsx
+++ b/src/components/map/lazy-map.tsx
@@ -3,12 +3,14 @@
 import { MapContainer, TileLayer } from "react-leaflet";
 import L, { FitBoundsOptions } from "leaflet";
 import "leaflet/dist/leaflet.css";
-import { Fragment, ReactElement, ReactNode } from "react";
+import { ReactNode } from "react";
 import "./map.css";
+import MapMarker from "./map-marker";
+import { TLazyMapMarkerProps } from "./lazy-map-marker";
 
 type TLazyMapProps = {
   children?: ReactNode;
-  markers?: ReactElement[];
+  markersData?: TLazyMapMarkerProps[];
   className?: string;
   center?: [number, number];
   zoom?: number;
@@ -18,7 +20,7 @@ type TLazyMapProps = {
 
 function LazyMap({
   children,
-  markers,
+  markersData,
   className,
   center,
   zoom,
@@ -38,10 +40,9 @@ function LazyMap({
     boundsOptions?: FitBoundsOptions;
     zoom?: number;
   } = {};
-  if (autoBounds && markers) {
-    boundsOrCenterAndZoom.bounds = markers.map(
-      (marker) => marker.props.position
-    );
+
+  if (autoBounds && markersData) {
+    boundsOrCenterAndZoom.bounds = markersData.map(({ position }) => position);
     boundsOrCenterAndZoom.boundsOptions = { padding: [30, 60] };
   } else {
     boundsOrCenterAndZoom.center = center;
@@ -59,8 +60,13 @@ function LazyMap({
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
 
-      {markers?.map((marker, index) => (
-        <Fragment key={index}>{marker}</Fragment>
+      {markersData?.map(({ type, position, popupContent }, index) => (
+        <MapMarker
+          key={index}
+          type={type}
+          position={position}
+          popupContent={popupContent}
+        />
       ))}
 
       {children}


### PR DESCRIPTION
on crag info page a map was loaded with autobounds property. but markers passed into map were also dynamically loaded components, so map did not get markers' props in time.

map now gets markers props as an object